### PR TITLE
Add assertions to the codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ text-ui-test/EXPECTED-UNIX.TXT
 *.class
 data/
 *.jar
+
+/build/**/META-INF/
+/out/**/META-INF/
+

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: dippy.Launcher
+

--- a/src/main/java/dippy/Main.java
+++ b/src/main/java/dippy/Main.java
@@ -11,6 +11,7 @@ import javafx.scene.Scene;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 

--- a/src/main/java/dippy/task/Deadline.java
+++ b/src/main/java/dippy/task/Deadline.java
@@ -25,6 +25,7 @@ public class Deadline extends Task {
      * @return The Deadline task object that was represented by the user input
      */
     public static Deadline parseToTask(String[] fields) {
+        assert(fields.length >= 4);
         boolean isTaskDone = fields[1].equals("1") ? true : false;
         String taskName = fields[2];
         String deadlineDate = fields[3];

--- a/src/main/java/dippy/task/Event.java
+++ b/src/main/java/dippy/task/Event.java
@@ -39,6 +39,7 @@ public class Event extends Task {
      * @return The Event task object that was represented by the user input
      */
     public static Event parseToTask(String[] fields) {
+        assert(fields.length >= 6);
         boolean isTaskDone = fields[1].equals("1") ? true : false;
         String taskName = fields[2];
         String startDate = fields[3];

--- a/src/main/java/dippy/task/Task.java
+++ b/src/main/java/dippy/task/Task.java
@@ -47,6 +47,7 @@ public class Task {
      * @return The Task object that was represented by the user input
      */
     public static Task parseToTask(String[] fields) {
+        assert(fields.length >= 2);
         boolean isTaskDone = fields[1].equals("1") ? true : false;
         String taskName = fields[2];
         Task newTask = new Task(taskName);

--- a/src/main/java/dippy/ui/MainWindow.java
+++ b/src/main/java/dippy/ui/MainWindow.java
@@ -64,8 +64,12 @@ public class MainWindow extends AnchorPane {
     @FXML
     public void handleUserInput() throws DippyException {
         DialogBox userText = DialogBox.getUserDialog(userInput.getText(), userImage);
-
         Response dippyResponse = Parser.parseUserInput(userInput.getText());
+
+        // Invalid user input shouldn't reach this line (DippyException should be thrown)
+        // Check if Response object obtained after parsing valid user input
+        assert(dippyResponse != null);
+
         DialogBox dippyText = DialogBox.getDippyDialog(dippyResponse.getReply(), dippyImage);
         dialogContainer.getChildren().addAll(userText, dippyText);
 


### PR DESCRIPTION
Dippy's codebase did not have any assertions.

This leaves Dippy vulnerable to continue programme execution despite encountering bugs.

Let's
* assert that parsing a valid user input should always return a Response object.
* assert that user commands fulfill the minimum length of tokens required for that command

Implementing these assertions ensure that the Dippy programme is running correctly as intended.